### PR TITLE
Upon Parent re-connection after a channel switch g_rootless_flag required to be updated on Root as well as on Leaf.

### DIFF
--- a/components/mwifi/mwifi.c
+++ b/components/mwifi/mwifi.c
@@ -174,11 +174,7 @@ static void esp_mesh_event_cb(void *arg, esp_event_base_t event_base, int32_t ev
             MDF_LOGI("Parent is connected");
             mwifi_connected_flag = true;
             s_disconnected_count = 0;
-
-            if (esp_mesh_is_root()) {
-                g_rootless_flag = false;
-            }
-
+            g_rootless_flag = false;
             break;
         }
 


### PR DESCRIPTION
On the file mwifi.c

**How to Recreate the Scenario:**
- When root within mesh gets a channel switch by the router. (this channel change could be due to any possible reason)
- Root reconnects to the router through that new channel and so all leaf nodes reconnects to the root with this new channel.
- Just before reconnection, Leafs get into the rootless state. 
so MESH_EVENT_NETWORK_STATE event occurs and so g_rootless_flag is now set to true for all leafs.
- further, all leafs will start looking for another parent with same mesh ID and password.
- Eventually when they find the root on another channel - all leafs will start reconnecting to the root.
- Here, when MESH_EVENT_PARENT_CONNECTED event occurs on the leafs - we have to set the g_rootless_flag to false for all leafs as well as for root. (Currently it is not doing it. see proposed change.)

**Line 177: g_rootless_flag required to be updated on both Root and Leaf If the parent get re-connected after a channel switch.**

**What happens without this change:**
- Without above mentioned change, when the channel switch happens (could be initialized by router due to any possible reason) after going through the reconnection sequence - Root will get connected to the router and so all leafs will get reconnected to the root. 
- Here upon re-connection Root has g_rootless_flag set to false BUT Leafs still have g_rootless_flag set to true. Leafs are still in rootless state.
- Now, when root sends any data to leafs, all leafs will be able to receive the data as they are part of the mesh.
- However, when leaf will try to send data to the root, 
at Line 861:     `MDF_ERROR_CHECK(to_root && g_rootless_flag, MDF_ERR_MWIFI_NO_ROOT, "Current network has no root");
`
Because the leaf do not have g_rootless_flag set to false after the channel switch - Leaf will not be able to send data to the root and it will keep sending an error message stating "Current network has no root".

So proposed change is working for me and has resolved the issue. Please verify this and update here if espressif team is good with this change.

Thank you.