### PR TITLE
Correction to url parser

### DIFF
--- a/examples/function_demo/mupgrade/main/mupgrade_example.c
+++ b/examples/function_demo/mupgrade/main/mupgrade_example.c
@@ -148,7 +148,7 @@ static void ota_task()
     } while (ret != MDF_OK);
 
     total_size = esp_http_client_fetch_headers(client);
-    sscanf(CONFIG_FIRMWARE_UPGRADE_URL, "%*[^//]//%*[^/]/%[^.bin]", name);
+    sscanf(CONFIG_FIRMWARE_UPGRADE_URL, "%*[^/]//%*[^/]/%[^.]", name);
 
     if (total_size <= 0) {
         MDF_LOGW("Please check the address of the server");


### PR DESCRIPTION
%[^.bin] match any character but the ones in the ".bin" string, in an individual manner not as a whole string. This means that, for example, "firmware.bin" will match all the characters up to the first "i" it encounters. This result in the variable name having the value "f" instead of "firmware"
other examples:
"new_soft.bin"-> ""
"myBrandNewCode.bin"-> "myBra"
"update_file.bin" -> "update_f"

%*[^//] isn't creating any error, but the second "/" doesn't do anything.