### PR TITLE
added logic to not include blufi if nimble is used as ble host

### DIFF
--- a/components/mconfig/mconfig_blufi.c
+++ b/components/mconfig/mconfig_blufi.c
@@ -15,6 +15,8 @@
 #include "sdkconfig.h"
 
 #if CONFIG_BT_ENABLED
+#if !CONFIG_BT_NIMBLE_ENABLED
+
 
 #include "esp_bt.h"
 #include "esp_blufi_api.h"
@@ -1183,5 +1185,6 @@ mdf_err_t mconfig_blufi_send(uint8_t *data, size_t size)
 
     return MDF_OK;
 }
-
+#endif /**< !CONFIG_BT_NIMBLE_ENABLED */
 #endif /**< CONFIG_BT_ENABLED */
+

--- a/components/mlink/mlink_ble.c
+++ b/components/mlink/mlink_ble.c
@@ -16,6 +16,7 @@
 #include "mlink_ble.h"
 
 #if CONFIG_BT_ENABLED
+#if !CONFIG_BT_NIMBLE_ENABLED
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -616,3 +617,4 @@ mdf_err_t mlink_ble_set_cb(const mlink_ble_cb_t read_cb, const mlink_ble_cb_t wr
 }
 
 #endif /**< CONFIG_BT_ENABLED */
+#endif /**< !CONFIG_BT_NIMBLE_ENABLED */

--- a/components/mlink/mlink_sniffer.c
+++ b/components/mlink/mlink_sniffer.c
@@ -198,13 +198,15 @@ static void sniffer_wifi_cb(void *recv_buf, wifi_promiscuous_pkt_type_t type)
 }
 
 #if CONFIG_BT_ENABLED
+#if !CONFIG_BT_NIMBLE_ENABLED
 #include "esp_gap_ble_api.h"
 #endif /**< CONFIG_BT_ENABLED */
-
+#endif /**< !CONFIG_BT_NIMBLE_ENABLED */
 #ifdef CONFIG_IDF_TARGET_ESP32
 static mdf_err_t mlink_sniffer_ble_cb(void *data, size_t size)
 {
 #if CONFIG_BT_ENABLED
+#if !CONFIG_BT_NIMBLE_ENABLED
 
     esp_ble_gap_cb_param_t *scan_result = (esp_ble_gap_cb_param_t *)data;
     uint8_t adv_name_len = 0;
@@ -239,7 +241,7 @@ static mdf_err_t mlink_sniffer_ble_cb(void *data, size_t size)
     mlink_sniffer_list_insert(sniffer_data);
 
     MDF_FREE(sniffer_data);
-
+#endif /**< !CONFIG_BT_NIMBLE_ENABLED */
 #endif /**< CONFIG_BT_ENABLED */
 
     return ESP_OK;


### PR DESCRIPTION
I'm using mdf to create a mesh but using nimble as bluetooth host, mconfig-blufi is not implemented for nimble but I think everything else should be compatible in mdf. So I just added some logic to avoid the compiles errors due to the missing .h from bluedroid that are not included if nimble is selected as host. 
