### PR TITLE
fix: examples CMakeLists.txt MDF_PATH defined check

### DIFF
--- a/examples/aliyun_linkkit/get-started/CMakeLists.txt
+++ b/examples/aliyun_linkkit/get-started/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../../..)
 endif()
 include($ENV{MDF_PATH}/project.cmake)

--- a/examples/aliyun_linkkit/mesh-with-aliyun/CMakeLists.txt
+++ b/examples/aliyun_linkkit/mesh-with-aliyun/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../../..)
 endif()
 include($ENV{MDF_PATH}/project.cmake)

--- a/examples/aliyun_linkkit/test/CMakeLists.txt
+++ b/examples/aliyun_linkkit/test/CMakeLists.txt
@@ -12,7 +12,7 @@ set(EXTRA_COMPONENT_DIRS "../../../components")
 #
 set(TEST_COMPONENTS "aliyun_sdk" CACHE STRING "List of components to test")
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../../..)
 endif()
 include($ENV{MDF_PATH}/project.cmake)

--- a/examples/development_kit/buddy/CMakeLists.txt
+++ b/examples/development_kit/buddy/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../../..)
 endif()
 include($ENV{MDF_PATH}/project.cmake)

--- a/examples/development_kit/button/CMakeLists.txt
+++ b/examples/development_kit/button/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../../..)
 endif()
 include($ENV{MDF_PATH}/project.cmake)

--- a/examples/development_kit/light/CMakeLists.txt
+++ b/examples/development_kit/light/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../../..)
 endif()
 include($ENV{MDF_PATH}/project.cmake)

--- a/examples/development_kit/sense/CMakeLists.txt
+++ b/examples/development_kit/sense/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../../..)
 endif()
 include($ENV{MDF_PATH}/project.cmake)

--- a/examples/function_demo/mcommon/CMakeLists.txt
+++ b/examples/function_demo/mcommon/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../../..)
 endif()
 include($ENV{MDF_PATH}/project.cmake)

--- a/examples/function_demo/mconfig/CMakeLists.txt
+++ b/examples/function_demo/mconfig/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../../..)
 endif()
 include($ENV{MDF_PATH}/project.cmake)

--- a/examples/function_demo/mdebug/CMakeLists.txt
+++ b/examples/function_demo/mdebug/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../../..)
 endif()
 include($ENV{MDF_PATH}/project.cmake)

--- a/examples/function_demo/mupgrade/CMakeLists.txt
+++ b/examples/function_demo/mupgrade/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../../..)
 endif()
 include($ENV{MDF_PATH}/project.cmake)

--- a/examples/function_demo/mwifi/console_test/CMakeLists.txt
+++ b/examples/function_demo/mwifi/console_test/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../../../../)
 endif()
 include($ENV{MDF_PATH}/project.cmake)

--- a/examples/function_demo/mwifi/mqtt_example/CMakeLists.txt
+++ b/examples/function_demo/mwifi/mqtt_example/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../../../../)
 endif()
 include($ENV{MDF_PATH}/project.cmake)

--- a/examples/function_demo/mwifi/no_router/CMakeLists.txt
+++ b/examples/function_demo/mwifi/no_router/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../../../..)
 endif()
 include($ENV{MDF_PATH}/project.cmake)

--- a/examples/function_demo/mwifi/root_on_ethernet/CMakeLists.txt
+++ b/examples/function_demo/mwifi/root_on_ethernet/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../../../..)
 endif()
 include($ENV{MDF_PATH}/project.cmake)

--- a/examples/function_demo/mwifi/router/CMakeLists.txt
+++ b/examples/function_demo/mwifi/router/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../../../..)
 endif()
 include($ENV{MDF_PATH}/project.cmake)

--- a/examples/get-started/CMakeLists.txt
+++ b/examples/get-started/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../..)
 endif()
 include($ENV{MDF_PATH}/project.cmake)

--- a/examples/wireless_debug/CMakeLists.txt
+++ b/examples/wireless_debug/CMakeLists.txt
@@ -8,7 +8,7 @@ message(FATAL_ERROR "Adafruit-GFX-Library is not downloaded and run, the followi
 message(FATAL_ERROR "git clone -b v1.2.3 https://github.com/adafruit/Adafruit-GFX-Library.git components/lcd/Adafruit-GFX-Library")
 endif()
 
-if(NOT DEFINED $ENV{MDF_PATH})
+if(NOT DEFINED ENV{MDF_PATH})
     set(ENV{MDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/../..)
 endif()
 include($ENV{MDF_PATH}/project.cmake)


### PR DESCRIPTION
The check of environment variable MDF_PATH existence wasn't working properly. Tested with [get-started](https://github.com/espressif/esp-mdf/tree/master/examples/get-started) but all examples had the same issue.